### PR TITLE
HIP_VISIBLE_DEVICES as default

### DIFF
--- a/hpc_launcher/cli/torchrun_hpc.py
+++ b/hpc_launcher/cli/torchrun_hpc.py
@@ -52,6 +52,16 @@ def main():
         "to limit how much GPU memory can be allocated.",
     )
 
+    parser.add_argument(
+        "-u",
+        "--unswap-rocr-hip-vis-dev",
+        action="store_true",
+        default=False,
+        help="Undo moving ROCR_VISIBLE_DEVICES into the HIP_VISIBLE_DEVICES env variable. "
+        "In PyTorch codes HIP_VISIBLE_DEVICES is most similar to CUDA_VISIBLE_DEVICES. "
+        "Ensureing that HIP vs ROCR can improve behavior of HF Accelerate and TorchTitan.",
+    )
+
     # Grab the rest of the command line to launch
     # torchrun-hpc does not support running with a pre-generated batch script file
     parser.add_argument("command", help="Command to be executed")
@@ -104,6 +114,9 @@ def main():
                     system.active_system_params.fraction_max_gpu_mem,
                 )
             )
+
+    if args.unswap_rocr_hip_vis_dev:
+        env_list.append(("TORCHRUN_HPC_UNSWAP_ROCR_HIP_VIS_DEV", "TRUE"))
 
     system.extend_environment_variables(env_list)
 

--- a/hpc_launcher/torch/__init__.py
+++ b/hpc_launcher/torch/__init__.py
@@ -27,7 +27,7 @@ if unswap_rocr_hip_vis_dev_env.lower() in ("true", "1", "yes", "on"):
 
 if os.getenv("ROCR_VISIBLE_DEVICES") and not unswap_rocr_hip_vis_dev:
     if os.getenv("HIP_VISIBLE_DEVICES"):
-        print(f'WARNING: overwritting HIP_VISIBLE_DEICES {os.getenv("HIP_VISIBLE_DEVICES")} with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
+        print(f'WARNING: overwriting HIP_VISIBLE_DEVICES {os.getenv("HIP_VISIBLE_DEVICES")} with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
 
     os.environ["HIP_VISIBLE_DEVICES"] = os.getenv("ROCR_VISIBLE_DEVICES")
     del os.environ["ROCR_VISIBLE_DEVICES"]

--- a/hpc_launcher/torch/__init__.py
+++ b/hpc_launcher/torch/__init__.py
@@ -13,6 +13,26 @@
 # SPDX-License-Identifier: (Apache-2.0)
 from psutil import Process
 import inspect
+import os
+
+# Optionally explicitly override HIP_VISIBLE_DEVICES with ROCR_VISIBLE_DEVICES before torch is imported
+# ROCR_VISIBLE_DEVICES - controls which GPUs a process can see
+# HIP_VISIBLE_DEVICES - controls which GPUs a process can use
+# PyTorch - behaves better when it can see all of the devices on a node, but knows which it should use
+unswap_rocr_hip_vis_dev_env = os.getenv("TORCHRUN_HPC_UNSWAP_ROCR_HIP_VIS_DEV", "False")
+# Convert to boolean
+unswap_rocr_hip_vis_dev = False
+if unswap_rocr_hip_vis_dev_env.lower() in ("true", "1", "yes", "on"):
+    unswap_rocr_hip_vis_dev = True
+
+if os.getenv("ROCR_VISIBLE_DEVICES") and not unswap_rocr_hip_vis_dev:
+    if os.getenv("HIP_VISIBLE_DEVICES"):
+        print(f'WARNING: overwritting HIP_VISIBLE_DEICES {os.getenv("HIP_VISIBLE_DEVICES")} with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
+    else:
+        print(f'WARNING: underwritting HIP_VISIBLE_DEICES with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
+
+    os.environ["HIP_VISIBLE_DEVICES"] = os.getenv("ROCR_VISIBLE_DEVICES")
+    del os.environ["ROCR_VISIBLE_DEVICES"]
 
 affinity = None
 if hasattr(Process, "cpu_affinity") and inspect.isfunction(Process.cpu_affinity):

--- a/hpc_launcher/torch/__init__.py
+++ b/hpc_launcher/torch/__init__.py
@@ -28,8 +28,6 @@ if unswap_rocr_hip_vis_dev_env.lower() in ("true", "1", "yes", "on"):
 if os.getenv("ROCR_VISIBLE_DEVICES") and not unswap_rocr_hip_vis_dev:
     if os.getenv("HIP_VISIBLE_DEVICES"):
         print(f'WARNING: overwritting HIP_VISIBLE_DEICES {os.getenv("HIP_VISIBLE_DEVICES")} with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
-    else:
-        print(f'WARNING: underwritting HIP_VISIBLE_DEICES with ROCR_VISIBLE_DEVICES {os.getenv("ROCR_VISIBLE_DEVICES")}')
 
     os.environ["HIP_VISIBLE_DEVICES"] = os.getenv("ROCR_VISIBLE_DEVICES")
     del os.environ["ROCR_VISIBLE_DEVICES"]


### PR DESCRIPTION
Add support to migrate ROCR_VISIBLE_DEVICES to HIP_VISIBLE_DEVICES by
default on AMD systems to improve GPU detection behavior with PyTorch 
sub-libraries such as TorchTitan and Accelerate.