### PR TITLE
Add --time-limit and --dependency

### DIFF
--- a/hpc_launcher/cli/common_args.py
+++ b/hpc_launcher/cli/common_args.py
@@ -240,6 +240,13 @@ def setup_arguments(parser: argparse.ArgumentParser):
     )
 
     group.add_argument(
+        "-J",
+        "--job-name",
+        default=None,
+        help="Specify a name to use fo the job",
+    )
+
+    group.add_argument(
         "--reservation",
         default=None,
         help="Add a reservation arguement to scheduler.  "

--- a/hpc_launcher/cli/common_args.py
+++ b/hpc_launcher/cli/common_args.py
@@ -91,6 +91,14 @@ def setup_arguments(parser: argparse.ArgumentParser):
 
     group.add_argument("-q", "--queue", default=None, help="Specifies the queue to use")
 
+    group.add_argument(
+        "-t",
+        "--time-limit",
+        type=int,
+        default=None,
+        help="Set a time limit for the job in minutes",
+    )
+
     # Constraints
     group.add_argument(
         "-g",
@@ -223,6 +231,12 @@ def setup_arguments(parser: argparse.ArgumentParser):
         "--account",
         default=None,
         help="Specify the account (or bank) to use fo the job",
+    )
+
+    group.add_argument(
+        "--dependency",
+        default=None,
+        help="Specify a scheduler dependency of the submitted job.",
     )
 
     group.add_argument(

--- a/hpc_launcher/schedulers/flux.py
+++ b/hpc_launcher/schedulers/flux.py
@@ -73,7 +73,16 @@ class FluxScheduler(Scheduler):
             self.common_launch_args['--env=LD_PRELOAD'] = f'{",".join(self.ld_preloads)}'
 
         if self.time_limit is not None:
-            self.common_launch_args["--time"] = f"{self.time_limit}m"
+            if blocking:
+                self.common_launch_args["--time"] = f"{self.time_limit}m"
+            else:
+                self.submit_only_args["--time"] = f"{self.time_limit}m"
+
+        dependency = self.common_launch_args.get('--dependency', None)
+        if dependency and not blocking:
+            del self.common_launch_args['--dependency']
+            del self.override_launch_args['--dependency']
+            self.submit_only_args["--dependency"] = dependency
 
         if self.job_name:
             self.common_launch_args["--job-name"] = f"{self.job_name}"

--- a/hpc_launcher/schedulers/scheduler.py
+++ b/hpc_launcher/schedulers/scheduler.py
@@ -66,6 +66,8 @@ class Scheduler:
     account: Optional[str] = None
     # The reservation to use for the scheduler
     reservation: Optional[str] = None
+    # Time limit (in minutes), default is no limit
+    dependency: Optional[str] = None
     # Hijack preload commands into a scheduler
     ld_preloads: Optional[list[str]] = None
     # Capture the original command so that it can be added to the launch script
@@ -88,6 +90,7 @@ class Scheduler:
 
     def build_command_string_and_batch_script(
             self, system: "System", blocking: bool = True, cli_env_only: bool = False,
+            for_launch_cmd: bool = True,
     ) -> (str, list[str]):
         """
         Returns the strings used for a launch command as well as a batch script
@@ -98,6 +101,7 @@ class Scheduler:
         :param system: The system to use.
         :param blocking: Is the job interactive of blocking
         :param cli_env_only: Append environment variables to CLI not a launch script
+        :param for_launch_cmd:  Some args should not be in both the header and launch cmnd. Ex: flux --dependency=afterany:XXX
         :return: A tuple of (shell script as a string, list of command-line arguments).
         """
         env_vars = system.environment_variables()
@@ -149,11 +153,15 @@ class Scheduler:
         if not blocking: # Only add batch script header items on non-blocking calls
             prefix = self.batch_script_prefix()
             for k,v in self.submit_only_args.items():
+                if not for_launch_cmd and k == '--dependency':
+                    continue
                 if not v:
                     header.write(f"{prefix} {k}\n")
                 else:
                     header.write(f"{prefix} {k}={v}\n")
             for k,v in self.common_launch_args.items():
+                if not for_launch_cmd and k == '--dependency':
+                    continue
                 if not v:
                     header.write(f"{prefix} {k}\n")
                 else:
@@ -300,7 +308,7 @@ class Scheduler:
         script = ""
         # Launch command only use the cmd_args to construct the shell script to be launched
         (header_lines, cmd_args) = self.build_command_string_and_batch_script(
-            system, blocking, False,
+            system, blocking, False, for_launch_cmd=False
         )
         # For batch jobs add any common args to the internal command
         if not blocking:

--- a/hpc_launcher/schedulers/slurm.py
+++ b/hpc_launcher/schedulers/slurm.py
@@ -83,6 +83,23 @@ class SlurmScheduler(Scheduler):
         if self.time_limit is not None:
             self.common_launch_args["--time"] = f"{_time_string(self.time_limit)}"
 
+        if self.dependency is not None:
+            self.common_launch_args["--dependency"] = f"{self.dependency}"
+        dependency = self.common_launch_args.get('--dependency', None)
+        if self.override_launch_args and self.override_launch_args.get('--dependency', None):
+            dependency = self.override_launch_args['--dependency']
+        if dependency and not blocking:
+            try:
+                del self.common_launch_args['--dependency']
+            except KeyError:
+                pass
+            try:
+                if self.override_launch_args:
+                    del self.override_launch_args['--dependency']
+            except KeyError:
+                pass
+            self.submit_only_args["--dependency"] = dependency
+
         if self.job_name:
             self.common_launch_args["--job-name"] = f"{self.job_name}"
 

--- a/hpc_launcher/systems/lc/cts2.py
+++ b/hpc_launcher/systems/lc/cts2.py
@@ -59,8 +59,8 @@ class CTS2(System):
 
     def customize_scheduler(self, scheduler):
         if self.system_name == "matrix" and type(scheduler) is SlurmScheduler:
-            scheduler.common_launch_args["--mpibind"] = "off"
-            scheduler.common_launch_args["--gpu-bind"] = "none"
+            scheduler.run_only_args["--mpibind"] = "off"
+            scheduler.run_only_args["--gpu-bind"] = "none"
 
         return
 

--- a/tests/test_batch_script_sleep.sh
+++ b/tests/test_batch_script_sleep.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+hostname
+date
+sleep 10
+hostname
+date

--- a/tests/test_batch_script_sleep.sh
+++ b/tests/test_batch_script_sleep.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-hostname
-date
-sleep 10
-hostname
-date


### PR DESCRIPTION
Added support for setting the job time limit from the CLI as well as
the jobs dependency.

This can be tested with something like: `launch -N1 -n1 -v --dependency=singleton --bg --job-name=BVEtest -- tests/test_batch_script_sleep.sh`